### PR TITLE
Add Helm chart for QuakeWatch 0.1.1

### DIFF
--- a/helm/quakewatch/Chart.yaml
+++ b/helm/quakewatch/Chart.yaml
@@ -3,4 +3,4 @@ name: quakewatch
 description: A Helm chart for QuakeWatch Flask app
 type: application
 version: 0.1.0
-appVersion: "1.0.0"
+appVersion: "1.1.0"


### PR DESCRIPTION
Added Helm chart in `helm/quakewatch/` with Deployment, Service, HPA, CronJob, ConfigMap, and Secret. Bumped chart version to 0.1.1.